### PR TITLE
remove inaccurate "about" info

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@
 ## About
 editdata.org repurposes components from [flatsheet](http://github.com/flatsheet/flatsheet) to provide a a simple free tool for editing data.
 
-Currently the app is limited to editing & publishing data from gists. Each dataset creates a gist with 3 important files:
-
-- data.json, a json file with an array of objects in `{ key: '', value: {} }` format. All the data is in the `value` property.
-- data.csv, a csv file that you can import into various software.
-- metadata.json, a json file that for now only contains the names of columns.
-
 ## Contributing
 
 [Read more about how to contribute to editdata.org.](CONTRIBUTING.md)


### PR DESCRIPTION
This is what I took out:

```
Currently the app is limited to editing & publishing data from gists. Each dataset creates a gist with 3 important files:

- data.json, a json file with an array of objects in `{ key: '', value: {} }` format. All the data is in the `value` property.
- data.csv, a csv file that you can import into various software.
- metadata.json, a json file that for now only contains the names of columns.
```

As far as I can tell, nearly every part of this description isn't current.

 * I don't see any functionality for working with gist.github.com (and ps I would welcome such functionality).
 * The listed filenames never appear, even as defaults.
 * The JSON format that editdata.org produces is not the one listed. (ps the one listed is weird.)
 * I don't see any of this `metadata.json` stuff...

Am I missing something? Should something else go in place of these deleted things? Pull request submitted in the interest of preferring no data to incorrect data.